### PR TITLE
Adding check_output example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Here is an example of the maptemplate and cam2map commands in Pysis:
     isis.cam2map(from_=cal_name, to=proj_name, pixres='map',
                  map='MDIS_eqr.map',defaultrange='map')
 
+### Getting values from ISIS commands
+
+Here is an example of how to receive values that are returned on STDOUT from ISIS tools.
+The example command we are using is `getkey` to receive values from the label of an
+ISIS cube:
+
+    value = getkey.check_output(from_='W1467351325_4.map.cal.cub',
+                                keyword='minimumringradius',
+                                grp='mapping')
+
 ### Multiprocessing Isis Commands with IsisPool
 
 Pysis has built-in support to make multiprocessing isis commands simple. To run

--- a/pysis/util/file_manipulation.py
+++ b/pysis/util/file_manipulation.py
@@ -29,6 +29,7 @@ __all__ = [
     'file_variations'
 ]
 
+
 def write_file_list(filename, file_list=[], glob=None):
     """ Write a list of files to a file.
 
@@ -54,10 +55,11 @@ def file_variations(filename, extensions):
 
     Arguments:
         filename: The original file name to use as a base.
-        extensions: A list of file extensions to to generate new filenames.
+        extensions: A list of file extensions to generate new filenames.
     """
     (label, ext) = splitext(filename)
     return [label + extention for extention in extensions]
+
 
 class ImageName(object):
     def __init__(self, base):


### PR DESCRIPTION
I'm adding an example to the readme for getkey.check_output.
Also fixed a typo in the docstrings of file_manipulation.py and added some PEP8 lines.