### PR TITLE
removing confusing references to, I assume, old PysisPool reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Pysis has built-in support to make multiprocessing isis commands simple. To run
 the above MDIS calibration script for multiple images in multiple processes we
 could rewrite the function as so:
 
-    from pysis import PysisPool
+    from pysis import IsisPool
     from pysis.util import file_variations
 
     def calibrate_mdis(images):

--- a/pysis/isispool.py
+++ b/pysis/isispool.py
@@ -26,7 +26,7 @@ Usage:
         spiceinit from=filename.cub
         mdiscal from=filename.cub to=filename.cal.cub
 
-    from pysis import PysisPool
+    from pysis import IsisPool
     from pysis.util import file_variations
 
     def calibrate_mdis(images):


### PR DESCRIPTION
instead of `IsisPool`.